### PR TITLE
fix(build): update publish automation to package correct assets

### DIFF
--- a/.autorc.yaml
+++ b/.autorc.yaml
@@ -1,6 +1,7 @@
 plugins:
   - - npm
     - setRcToken: false
+      publishFolder: "dist/@tylertech/tyler-icons"
   - conventional-commits
   - released
 author: GitHub Actions <41898282+github-actions[bot]@users.noreply.github.com>

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,148 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@auto-canary/bot-list": {
+      "version": "10.33.0--canary.2115.25151.0",
+      "resolved": "https://tylertech.jfrog.io/artifactory/api/npm/npm/@auto-canary/bot-list/-/bot-list-10.33.0--canary.2115.25151.0.tgz",
+      "integrity": "sha1-bxhUb7xID1O0pPEWsB4yV2OtZ8Q=",
+      "dev": true
+    },
+    "@auto-canary/core": {
+      "version": "10.33.0--canary.2115.25151.0",
+      "resolved": "https://tylertech.jfrog.io/artifactory/api/npm/npm/@auto-canary/core/-/core-10.33.0--canary.2115.25151.0.tgz",
+      "integrity": "sha1-4dMlSx+yM5Go7NB2FzKP8ucDQ8s=",
+      "dev": true,
+      "requires": {
+        "@auto-canary/bot-list": "10.33.0--canary.2115.25151.0",
+        "@endemolshinegroup/cosmiconfig-typescript-loader": "^3.0.2",
+        "@octokit/plugin-enterprise-compatibility": "^1.2.2",
+        "@octokit/plugin-retry": "^3.0.1",
+        "@octokit/plugin-throttling": "^3.2.0",
+        "@octokit/rest": "^18.0.0",
+        "await-to-js": "^3.0.0",
+        "chalk": "^4.0.0",
+        "cosmiconfig": "7.0.0",
+        "deepmerge": "^4.0.0",
+        "dotenv": "^8.0.0",
+        "endent": "^2.0.1",
+        "enquirer": "^2.3.4",
+        "env-ci": "^5.0.1",
+        "fast-glob": "^3.1.1",
+        "fp-ts": "^2.5.3",
+        "fromentries": "^1.2.0",
+        "gitlog": "^4.0.3",
+        "https-proxy-agent": "^5.0.0",
+        "import-cwd": "^3.0.0",
+        "import-from": "^3.0.0",
+        "io-ts": "^2.1.2",
+        "lodash.chunk": "^4.2.0",
+        "log-symbols": "^4.0.0",
+        "node-fetch": "2.6.1",
+        "parse-author": "^2.0.0",
+        "parse-github-url": "1.0.2",
+        "pretty-ms": "^7.0.0",
+        "requireg": "^0.2.2",
+        "semver": "^7.0.0",
+        "signale": "^1.4.0",
+        "tapable": "^2.2.0",
+        "terminal-link": "^2.1.1",
+        "tinycolor2": "^1.4.1",
+        "ts-node": "^9.1.1",
+        "tslib": "2.1.0",
+        "type-fest": "^0.21.1",
+        "typescript-memoize": "^1.0.0-alpha.3",
+        "url-join": "^4.0.0"
+      },
+      "dependencies": {
+        "cosmiconfig": {
+          "version": "7.0.0",
+          "resolved": "https://tylertech.jfrog.io/artifactory/api/npm/npm/cosmiconfig/-/cosmiconfig-7.0.0.tgz",
+          "integrity": "sha1-75tE13OVnK5j3ezRIt4jhTtg+NM=",
+          "dev": true,
+          "requires": {
+            "@types/parse-json": "^4.0.0",
+            "import-fresh": "^3.2.1",
+            "parse-json": "^5.0.0",
+            "path-type": "^4.0.0",
+            "yaml": "^1.10.0"
+          }
+        },
+        "log-symbols": {
+          "version": "4.1.0",
+          "resolved": "https://tylertech.jfrog.io/artifactory/api/npm/npm/log-symbols/-/log-symbols-4.1.0.tgz",
+          "integrity": "sha1-P727lbRoOsn8eFER55LlWNSr1QM=",
+          "dev": true,
+          "requires": {
+            "chalk": "^4.1.0",
+            "is-unicode-supported": "^0.1.0"
+          }
+        },
+        "tapable": {
+          "version": "2.2.1",
+          "resolved": "https://tylertech.jfrog.io/artifactory/api/npm/npm/tapable/-/tapable-2.2.1.tgz",
+          "integrity": "sha1-GWenPvQGCoLxKrlq+G1S/bdu7KA=",
+          "dev": true
+        },
+        "tslib": {
+          "version": "2.1.0",
+          "resolved": "https://tylertech.jfrog.io/artifactory/api/npm/npm/tslib/-/tslib-2.1.0.tgz",
+          "integrity": "sha1-2mCGDxwuyqVwOrfTm8Bba/mIuXo=",
+          "dev": true
+        },
+        "url-join": {
+          "version": "4.0.1",
+          "resolved": "https://tylertech.jfrog.io/artifactory/api/npm/npm/url-join/-/url-join-4.0.1.tgz",
+          "integrity": "sha1-tkLiGiZGgI/6F4xMX9o5hE4Szec=",
+          "dev": true
+        }
+      }
+    },
+    "@auto-canary/npm": {
+      "version": "10.33.0--canary.2115.25151.0",
+      "resolved": "https://tylertech.jfrog.io/artifactory/api/npm/npm/@auto-canary/npm/-/npm-10.33.0--canary.2115.25151.0.tgz",
+      "integrity": "sha1-d4TikqFLzAsNb5YItcfDNDD/aSA=",
+      "dev": true,
+      "requires": {
+        "@auto-canary/core": "10.33.0--canary.2115.25151.0",
+        "@auto-canary/package-json-utils": "10.33.0--canary.2115.25151.0",
+        "await-to-js": "^3.0.0",
+        "endent": "^2.0.1",
+        "env-ci": "^5.0.1",
+        "fp-ts": "^2.5.3",
+        "get-monorepo-packages": "^1.1.0",
+        "io-ts": "^2.1.2",
+        "registry-url": "^5.1.0",
+        "semver": "^7.0.0",
+        "tslib": "2.1.0",
+        "typescript-memoize": "^1.0.0-alpha.3",
+        "url-join": "^4.0.0",
+        "user-home": "^2.0.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.1.0",
+          "resolved": "https://tylertech.jfrog.io/artifactory/api/npm/npm/tslib/-/tslib-2.1.0.tgz",
+          "integrity": "sha1-2mCGDxwuyqVwOrfTm8Bba/mIuXo=",
+          "dev": true
+        },
+        "url-join": {
+          "version": "4.0.1",
+          "resolved": "https://tylertech.jfrog.io/artifactory/api/npm/npm/url-join/-/url-join-4.0.1.tgz",
+          "integrity": "sha1-tkLiGiZGgI/6F4xMX9o5hE4Szec=",
+          "dev": true
+        }
+      }
+    },
+    "@auto-canary/package-json-utils": {
+      "version": "10.33.0--canary.2115.25151.0",
+      "resolved": "https://tylertech.jfrog.io/artifactory/api/npm/npm/@auto-canary/package-json-utils/-/package-json-utils-10.33.0--canary.2115.25151.0.tgz",
+      "integrity": "sha1-lNmIm7IPhO+YfZT62HWv+XJwE+s=",
+      "dev": true,
+      "requires": {
+        "parse-author": "^2.0.0",
+        "parse-github-url": "1.0.2"
+      }
+    },
     "@auto-it/bot-list": {
       "version": "10.32.3",
       "resolved": "https://tylertech.jfrog.io/artifactory/api/npm/npm/@auto-it/bot-list/-/bot-list-10.32.3.tgz",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "copy:package:readme": "cpx README.md dist/@tylertech/tyler-icons",
     "changelog": "auto changelog",
     "generate:metadata": "node ./scripts/generate-icon-metadata.js",
-    "release": "auto shipit"
+    "release": "auto shipit",
+    "postversion": "cd dist/@tylertech/tyler-icons && npm version $npm_package_version --no-git-tag-version --no-commit-hooks --ignore-scripts"
   },
   "keywords": [
     "tyler",
@@ -40,6 +41,7 @@
   "author": "Kieran Nichols <kieran.nichols@tylertech.com>",
   "license": "ISC",
   "devDependencies": {
+    "@auto-canary/npm": "^10.33.0--canary.2115.25151.0",
     "@auto-it/conventional-commits": "^10.32.3",
     "@tylertech/tyler-components-web": "^1.4.0",
     "@webcomponents/webcomponentsjs": "^2.5.0",
@@ -53,6 +55,5 @@
     "svg-to-ts": "^6.0.0",
     "webpack": "^5.4.0",
     "webpack-cli": "^4.2.0"
-  },
-  "dependencies": {}
+  }
 }


### PR DESCRIPTION
Updates in this PR:
- Add `canary` package of NPM plugin from https://github.com/intuit/auto/pull/2115
  - Once merged upstream we can remove the explicit `@auto-canary/npm` package and use the bundled one
- Add postVersion script to update the package.json version in our publishFolder to ensure it matches the version `auto` will be setting during the release process.
  - This could be moved into a nodejs script to make it more portable, but since automated versioning is currently executed on a `linux` box, the inline script is acceptable. 
- Add `publishFolder` declaration to `.autorc` file.
  - NOTE: If we standardize a similar path across repositories, then the `.autorc` file doesn't have to be unique per repo/project. (Also we could consider a utility like https://github.com/shashkovdanil/clean-publish#readme for automating some of the package cleanup).  