### PR TITLE
fix: update metadata export path

### DIFF
--- a/.changeset/new-nights-search.md
+++ b/.changeset/new-nights-search.md
@@ -1,0 +1,5 @@
+---
+"@tylertech/tyler-icons": patch
+---
+
+fix metadata file path in exports

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
       "import": "./tyler-icons.mjs",
       "types": "./tyler-icons.d.ts"
     },
-    "./tyler-icons-metadata.json": "./dist/tyler-icons-metadata.json"
+    "./tyler-icons-metadata.json": "./tyler-icons-metadata.json"
   },
   "files": [
     "tyler-icons.mjs",


### PR DESCRIPTION
The metadata JSON file isn't nested inside a `dist` folder, so updating the path to match.